### PR TITLE
Allow specifying postgres default db name

### DIFF
--- a/bin/dump-to-s3-postgres.sh
+++ b/bin/dump-to-s3-postgres.sh
@@ -39,6 +39,11 @@ then
   usage
 fi
 
+if [ -z "$DEFAULT_DB_NAME" ]
+then
+  DEFAULT_DB_NAME="$DB_USER"
+fi
+
 echo "==> Starting backup of PostgreSQL Server $DB_HOST ..."
 DATE_STRING="$(date +%Y%m%d%H%M)"
 DUMP_DIR="/tmp/sqlbackups/$DB_HOST"
@@ -49,6 +54,7 @@ export PGPASSWORD="$DB_PASSWORD"
 DATABASES="$(psql \
   -U "$DB_USER" \
   -h "$DB_HOST" \
+  -d "$DEFAULT_DB_NAME" \
   -t \
   -c 'SELECT datname FROM pg_database WHERE NOT datistemplate' \
   | grep -Ev 'rdsadmin'


### PR DESCRIPTION
* By default, postgres will use the Username as the database name to connect to. If a database with the Username doesn't exist, to connection will fail.